### PR TITLE
Ignore incorrect Larastan error

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,3 +9,7 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
+    ignoreErrors:
+      -
+        identifier: larastan.noEnvCallsOutsideOfConfig
+        path: config/nomiai.php


### PR DESCRIPTION
Suppresses stupid error. Regrettably, the Larastan developers forgot that packages are a thing