### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,9 +18,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.5, 8.4, 8.3]
-        laravel: [12.*, 11.*]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,117 @@
+# AI Agent Guide for nomiai-php-laravel
+
+## Project Overview
+
+This is a **Laravel wrapper package** for the [Nomi.ai PHP SDK](https://github.com/oliverearl/nomiai-php). It's a Laravel service provider package that bridges the standalone SDK with Laravel's ecosystem, not a standalone application. The wrapper provides Laravel-specific integration (facades, config, HTTP adapter) while delegating actual API functionality to the base SDK.
+
+**Key Architecture Pattern**: Adapter pattern - `LaravelHttpGuzzleAdapter` (in `src/Adapters/`) implements `GuzzleHttp\ClientInterface` to wrap Laravel's `Http` facade, enabling Laravel's HTTP mocking features (`Http::fake()`) to work with the Guzzle-based SDK.
+
+## Critical Conventions
+
+### Strict Typing Everywhere
+**Every file** must begin with `declare(strict_types=1);` after the opening PHP tag. This is enforced by Pest architecture tests in `tests/ArchTest.php`. The test suite will fail without it.
+
+### Code Style: PER Standard
+Uses Laravel Pint with PER (PHP Evolving Recommendations) preset. Run `composer format` before committing. The preset is explicitly configured in `pint.json` as `"preset": "per"`.
+
+### Namespace Convention
+All classes use the namespace `Nomiai\PhpSdk\Laravel\*` (note the capitalization: `PhpSdk` not `PHPSdk`). This matches the base SDK's namespace pattern.
+
+## Development Workflows
+
+### Testing with Pest
+```bash
+composer test              # Run full test suite
+composer test-coverage     # With coverage report
+```
+
+Tests use Orchestra Testbench (see `tests/TestCase.php`) to simulate a Laravel environment. The base `TestCase` automatically sets `nomiai.api_key` to `'token'` in `getEnvironmentSetUp()`.
+
+### Static Analysis
+```bash
+composer analyse  # PHPStan (Larastan) level 5
+```
+
+PHPStan ignores the `larastan.noEnvCallsOutsideOfConfig` error for `config/nomiai.php` (see `phpstan.neon.dist`). This is intentional - `env()` calls are only allowed in config files per Laravel conventions.
+
+### Architecture Testing
+`tests/ArchTest.php` enforces:
+- Laravel, PHP, and security presets
+- Strict equality (`===` not `==`)
+- Strict types declaration
+- Namespace-based rules
+
+## Key Integration Points
+
+### Service Provider Registration (`src/NomiAIServiceProvider.php`)
+The provider binds `Nomiai\PhpSdk\NomiAI::class` (the base SDK class) into Laravel's container with:
+1. Config-driven API key/endpoint from `config/nomiai.php`
+2. Custom `LaravelHttpGuzzleAdapter` injected as the HTTP client
+3. Throws `NomiaiException::missingApiToken()` if `NOMIAI_API_KEY` is empty
+
+### Facade Pattern (`src/Facades/NomiAI.php`)
+Thin facade that proxies to the base SDK class. Uses `@mixin` PHPDoc to provide IDE autocomplete for all base SDK methods. The facade accessor returns `BaseNomiAI::class`, not a string literal.
+
+### Configuration (`config/nomiai.php`)
+Two keys only:
+- `api_key`: from `NOMIAI_API_KEY` env var
+- `endpoint`: from `NOMIAI_ENDPOINT` env var (defaults to `https://api.nomi.ai`)
+
+## HTTP Adapter Implementation
+
+The `LaravelHttpGuzzleAdapter` bridges two HTTP client paradigms:
+
+**Critical**: It implements `send()` and `request()` methods differently:
+- `send()`: Converts PSR-7 `RequestInterface` → Laravel HTTP request → PSR-7 `Response`
+- `request()`: Directly uses Laravel's `Http::send()` with method/URI/options
+
+Both methods:
+- Set `Authorization` header from options array (`token` key)
+- Force `Accept: application/json` and `Content-Type: application/json`
+- Include custom User-Agent: `Nomi.ai Laravel SDK (VERSION)`
+- Use `RequestOptions::HTTP_ERRORS => false` to prevent exceptions on HTTP errors
+
+## Exception Handling
+
+Only one custom exception: `NomiaiException extends RuntimeException`
+- Has static factory `missingApiToken()` 
+- Thrown when API key is empty/missing
+- Used in both service provider registration and adapter
+
+## Package Publishing
+
+This package auto-discovers via `composer.json` extra config:
+```json
+"extra": {
+    "laravel": {
+        "providers": ["NomiAIServiceProvider"],
+        "aliases": {"NomiAI": "NomiAI"}
+    }
+}
+```
+
+Config can be published: `php artisan vendor:publish --tag="nomiai-php-laravel-config"`
+
+## Version Support Matrix
+
+- PHP: `^8.3` (requires JSON extension)
+- Laravel: `^11.0 || ^12.0 || ^13.0`
+- Base SDK: `oliverearl/nomiai-php` `^v1.0.3`
+
+Check `composer.json` before adding new dependencies or changing minimum versions.
+
+## When Modifying Code
+
+1. **Always** add `declare(strict_types=1);` to new files
+2. Run `composer format` after changes (auto-formats to PER)
+3. Run `composer test` - includes architecture rule validation
+4. If touching the adapter: test with `Http::fake()` to ensure mocking still works
+5. Update `NomiAIServiceProvider::VERSION` constant for releases
+
+## Common Pitfalls
+
+- Don't add `env()` calls outside `config/nomiai.php` - Larastan will flag it
+- Don't use loose comparison (`==`) - architecture tests enforce strict equality
+- Don't inject `Request` or other Laravel HTTP classes into the adapter - it must implement Guzzle's `ClientInterface`
+- The facade proxies to `\Nomiai\PhpSdk\NomiAI` (base SDK), not a Laravel-specific class
+

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.3",
         "ext-json": "*",
-        "illuminate/contracts": "^11.0||^12.0",
+        "illuminate/contracts": "^11.0||^12.0|^13.0",
         "oliverearl/nomiai-php": "^v1.0.3",
         "spatie/laravel-package-tools": "^1.16"
     },
@@ -26,7 +26,7 @@
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
         "larastan/larastan": "^2.9||^3.0",
-        "orchestra/testbench": "^10.0.0|^9.0.0",
+        "orchestra/testbench": "^11.0.0|^10.0.0|^9.0.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",
         "phpstan/extension-installer": "^1.3||^2.0",


### PR DESCRIPTION
This pull request adds support for Laravel 13 and PHP 8.5, updates development dependencies, and introduces a comprehensive AI Agent Guide for contributors. The changes ensure compatibility with the latest Laravel and PHP versions, improve testing workflows, and provide clear documentation for development and integration.

**Framework and Language Support:**

- Added support for Laravel 13 by updating the `illuminate/contracts` dependency in `composer.json`, expanding the test matrix, and including Laravel 13 in the version support matrix. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L21-R29) [[2]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L21-R25) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R1-R117)
- Updated required PHP version in CI workflows to PHP 8.5, ensuring the package is tested against the latest PHP version.

**Development and Testing Improvements:**

- Updated `orchestra/testbench` dev dependency in `composer.json` to include support for Testbench 11, aligning with Laravel 13 compatibility.
- Expanded the GitHub Actions test matrix to cover Laravel 13 and Testbench 11 combinations, ensuring robust CI coverage for new framework versions.

**Documentation:**

- Added a detailed `AGENTS.md` guide outlining project architecture, conventions, testing workflows, integration points, and common pitfalls, providing essential onboarding and reference material for contributors.